### PR TITLE
Add support for computed vars

### DIFF
--- a/Sources/ForkedModelMacros/ForkedModelMacro.swift
+++ b/Sources/ForkedModelMacros/ForkedModelMacro.swift
@@ -63,13 +63,13 @@ public struct ForkedModelMacro: ExtensionMacro {
         // Get all vars
         let allPropertyVars: [VariableDeclSyntax] = structDecl.memberBlock.members.compactMap { member -> VariableDeclSyntax? in
             guard let varSyntax = member.decl.as(VariableDeclSyntax.self) else { return nil }
-            guard !varSyntax.isComputedVar() else { return nil }
+            guard !varSyntax.isComputed() else { return nil }
             return varSyntax
         }
         
         // Gather names of all mergeable properties
         let mergePropertyVars: [MergePropertyVar] = try structDecl.memberBlock.members.compactMap { member -> MergePropertyVar? in
-            guard let varSyntax = member.decl.as(VariableDeclSyntax.self), varSyntax.isMerged(), !varSyntax.isComputedVar()
+            guard let varSyntax = member.decl.as(VariableDeclSyntax.self), varSyntax.isMerged(), !varSyntax.isComputed()
                 else { return nil }
             let propertyMerge = try varSyntax.propertyMerge()
             return MergePropertyVar(varSyntax: varSyntax, merge: propertyMerge, propertyVariety: varSyntax.propertyVariety())
@@ -79,7 +79,7 @@ public struct ForkedModelMacro: ExtensionMacro {
         let backedPropertyVars: [BackedPropertyVar] = try structDecl.memberBlock.members.compactMap { member -> BackedPropertyVar? in
             guard let varSyntax = member.decl.as(VariableDeclSyntax.self),
                   let backing = try varSyntax.propertyBacking(),
-                  !varSyntax.isComputedVar()
+                  !varSyntax.isComputed()
                 else { return nil }
             return BackedPropertyVar(varSyntax: varSyntax, backing: backing)
         }

--- a/Sources/ForkedModelMacros/VariableDeclSyntaxExtensions.swift
+++ b/Sources/ForkedModelMacros/VariableDeclSyntaxExtensions.swift
@@ -15,7 +15,37 @@ extension VariableDeclSyntax {
             attribute.as(AttributeSyntax.self)?.attributeName.trimmedDescription == mergedLabel
         }
     }
-    
+
+    func isComputedVar() -> Bool {
+        let accessors = bindings.compactMap {
+            $0.accessorBlock?.accessors
+        }
+        // If no accessors, no reason to check
+        guard !accessors.isEmpty else { return false }
+        // For every accessors list check if at least one set is present otherwise return nil
+        guard accessors.contains(where: { decl -> Bool in
+            let accessorsDecl: AccessorDeclListSyntax
+            switch decl {
+            case .getter:
+                // It is get only
+                return true
+            case .accessors(let accessors):
+                // Has multiple accessors
+                accessorsDecl = accessors
+            }
+
+            for accessor in accessorsDecl {
+                // if has a set it is not computed
+                guard accessor.accessorSpecifier == .keyword(.set) else { continue }
+                return false
+            }
+
+            // If not setter found, it is computed
+            return true
+        }) else { return false }
+        return true
+    }
+
     func propertyMerge() throws -> PropertyMerge? {
         let propertyAttribute = self.attributes.first { attribute in
             attribute.as(AttributeSyntax.self)?.attributeName.trimmedDescription == mergedLabel

--- a/Tests/ForkedTests/ForkedModelMacros.swift
+++ b/Tests/ForkedTests/ForkedModelMacros.swift
@@ -360,6 +360,110 @@ final class ForkedModelMacrosSuite: XCTestCase {
             macros: Self.testMacros
         )
     }
+
+    func testVars() {
+        assertMacroExpansion(
+            """
+            @ForkedModel
+            private struct Note {
+                var text: String = ""
+            }
+            """,
+            expandedSource:
+            """
+            private struct Note {
+                var text: String = ""
+            }
+
+            extension Note: Forked.Mergeable {
+                public func merged(withSubordinate other: Self, commonAncestor: Self) throws -> Self {
+                    var merged = self
+                    if areEqualForForked(self.text, commonAncestor.text) {
+                merged.text = other.text
+                    } else {
+                merged.text = self.text
+                    }
+                    return merged
+                }
+            }
+            """,
+            macros: Self.testMacros
+        )
+    }
+
+    func testSimpleComputedVars() {
+        assertMacroExpansion(
+            """
+            @ForkedModel
+            private struct Note {
+                var text: String = ""
+                var textComputed: String {
+                    return text
+                }
+            }
+            """,
+            expandedSource:
+            """
+            private struct Note {
+                var text: String = ""
+                var textComputed: String {
+                    return text
+                }
+            }
+
+            extension Note: Forked.Mergeable {
+                public func merged(withSubordinate other: Self, commonAncestor: Self) throws -> Self {
+                    var merged = self
+                    if areEqualForForked(self.text, commonAncestor.text) {
+                merged.text = other.text
+                    } else {
+                merged.text = self.text
+                    }
+                    return merged
+                }
+            }
+            """,
+            macros: Self.testMacros
+        )
+    }
+
+    func testComplexComputedVars() {
+        assertMacroExpansion(
+            """
+            @ForkedModel
+            private struct Note {
+                var text: String = ""
+                var textComputed: String {
+                    get { text }
+                    set { text = newValue }
+                }
+            }
+            """,
+            expandedSource:
+            """
+            private struct Note {
+                var text: String = ""
+                var textComputed: String {
+                    get { text }
+                    set { text = newValue }
+                }
+            }
+
+            extension Note: Forked.Mergeable {
+                public func merged(withSubordinate other: Self, commonAncestor: Self) throws -> Self {
+                    var merged = self
+                    if areEqualForForked(self.text, commonAncestor.text) {
+                merged.text = other.text
+                    } else {
+                merged.text = self.text
+                    }
+                    return merged
+                }
+            }
+            """,
+            macros: Self.testMacros
+        )
+    }
 }
 #endif
 

--- a/Tests/ForkedTests/ForkedModelMacros.swift
+++ b/Tests/ForkedTests/ForkedModelMacros.swift
@@ -361,7 +361,7 @@ final class ForkedModelMacrosSuite: XCTestCase {
         )
     }
 
-    func testVars() {
+    func testVarThatIsNotUsingMergedMacro() {
         assertMacroExpansion(
             """
             @ForkedModel
@@ -378,7 +378,45 @@ final class ForkedModelMacrosSuite: XCTestCase {
             extension Note: Forked.Mergeable {
                 public func merged(withSubordinate other: Self, commonAncestor: Self) throws -> Self {
                     var merged = self
-                    if areEqualForForked(self.text, commonAncestor.text) {
+                    if self.text == commonAncestor.text {
+                merged.text = other.text
+                    } else {
+                merged.text = self.text
+                    }
+                    return merged
+                }
+            }
+            """,
+            macros: Self.testMacros
+        )
+    }
+
+    func testVarThatHaveSingleDidSetAccessor() {
+        assertMacroExpansion(
+            """
+            @ForkedModel
+            private struct Note {
+                var text: String = "" {
+                    didSet {
+                    
+                    }
+                }
+            }
+            """,
+            expandedSource:
+            """
+            private struct Note {
+                var text: String = "" {
+                    didSet {
+                    
+                    }
+                }
+            }
+
+            extension Note: Forked.Mergeable {
+                public func merged(withSubordinate other: Self, commonAncestor: Self) throws -> Self {
+                    var merged = self
+                    if self.text == commonAncestor.text {
                 merged.text = other.text
                     } else {
                 merged.text = self.text
@@ -414,7 +452,7 @@ final class ForkedModelMacrosSuite: XCTestCase {
             extension Note: Forked.Mergeable {
                 public func merged(withSubordinate other: Self, commonAncestor: Self) throws -> Self {
                     var merged = self
-                    if areEqualForForked(self.text, commonAncestor.text) {
+                    if self.text == commonAncestor.text {
                 merged.text = other.text
                     } else {
                 merged.text = self.text
@@ -427,7 +465,7 @@ final class ForkedModelMacrosSuite: XCTestCase {
         )
     }
 
-    func testComplexComputedVars() {
+    func testComputedVarThatHaveSetter() {
         assertMacroExpansion(
             """
             @ForkedModel
@@ -452,10 +490,60 @@ final class ForkedModelMacrosSuite: XCTestCase {
             extension Note: Forked.Mergeable {
                 public func merged(withSubordinate other: Self, commonAncestor: Self) throws -> Self {
                     var merged = self
-                    if areEqualForForked(self.text, commonAncestor.text) {
+                    if self.text == commonAncestor.text {
                 merged.text = other.text
                     } else {
                 merged.text = self.text
+                    }
+                    if self.textComputed == commonAncestor.textComputed {
+                        merged.textComputed = other.textComputed
+                    } else {
+                        merged.textComputed = self.textComputed
+                    }
+                    return merged
+                }
+            }
+            """,
+            macros: Self.testMacros
+        )
+    }
+
+    func testComputedVarThatHaveSetterAndDidSetter() {
+        assertMacroExpansion(
+            """
+            @ForkedModel
+            private struct Note {
+                var text: String = ""
+                var textComputed: String {
+                    get { text }
+                    set { text = newValue }
+                    didSet { }
+                }
+            }
+            """,
+            expandedSource:
+            """
+            private struct Note {
+                var text: String = ""
+                var textComputed: String {
+                    get { text }
+                    set { text = newValue }
+                    didSet { }
+                }
+            }
+
+            extension Note: Forked.Mergeable {
+                public func merged(withSubordinate other: Self, commonAncestor: Self) throws -> Self {
+                    var merged = self
+                    if self.text == commonAncestor.text {
+                merged.text = other.text
+                    } else {
+                merged.text = self.text
+                    }
+                    if self.textComputed == commonAncestor.textComputed {
+                        merged.textComputed = other.textComputed
+                    } else {
+                        merged.textComputed = self.textComputed
                     }
                     return merged
                 }


### PR DESCRIPTION
This PR fix the issues #14, and some unit tests are provided

An unresolved problem is the tabbing of the first lines in the expanded merging function, but it is not related to the issue, and It has not been yet found as an issue because no unit test where provided until this PR for checking the expansion of a property inside @ForkedModel that do not have an attached "@Merge" macro

(ex.)